### PR TITLE
feat: add OpenRouter provider support

### DIFF
--- a/src/protocols/adapters/openai/mod.rs
+++ b/src/protocols/adapters/openai/mod.rs
@@ -66,6 +66,7 @@ impl OpenAIProtocol {
                 capabilities.requires_region_routing = self.service_name.as_str() == "minimax";
                 capabilities
             }
+            "openrouter" => ProviderCapabilities::openrouter(),
             "xinference" => {
                 let mut capabilities = ProviderCapabilities::openai_compatible_text_only();
                 capabilities.auth_kind = crate::protocols::common::capabilities::AuthKind::None;

--- a/src/protocols/common/capabilities.rs
+++ b/src/protocols/common/capabilities.rs
@@ -262,6 +262,27 @@ impl ProviderCapabilities {
             region_key_scope_sensitive: true,
         }
     }
+
+    pub const fn openrouter() -> Self {
+        Self {
+            family: ProviderFamily::Custom,
+            auth_kind: AuthKind::Signature,
+            content_block_mode: ContentBlockMode::Standard,
+            streaming_protocol: StreamingProtocolKind::SseOpenAI,
+            supports_chat: true,
+            supports_streaming: true,
+            supports_embeddings: true,
+            supports_responses_api: false,
+            supports_tools: true,
+            supports_tool_choice: true,
+            supports_response_format: false,
+            reasoning_request_strategy: ReasoningRequestStrategy::EnableThinking,
+            stream_reasoning_strategy: StreamReasoningStrategy::None,
+            supports_multimodal_input: true,
+            requires_region_routing: false,
+            region_key_scope_sensitive: false,
+        }
+    }
 }
 
 impl Default for ProviderCapabilities {


### PR DESCRIPTION
When using the OpenAI interface to call the OpenRouter model, there will be an error:
```
openai does not support enable_thinking
```
This PR can solve this problem.