### PR TITLE
fix: convert message blocks to OpenAI-compatible format for third-party providers

### DIFF
--- a/src/protocols/common/request.rs
+++ b/src/protocols/common/request.rs
@@ -1,10 +1,60 @@
 //! Common Request Assembly Logic
 
-use crate::error::LlmConnectorError;
-use crate::types::{Message, Role};
+use {
+    crate::{
+        error::LlmConnectorError,
+        types::{DocumentSource, ImageSource, Message, MessageBlock, Role},
+    },
+    serde_json::{Value, json, to_value},
+};
+
+/// Convert a MessageBlock to OpenAI-compatible JSON format.
+/// Anthropic-format blocks (Image with Base64/Url source) are converted to
+/// OpenAI-format image_url blocks with data URIs.
+fn block_to_openai(block: &MessageBlock) -> Value {
+    match block {
+        MessageBlock::Text { text } => {
+            json!({"type": "text", "text": text})
+        }
+        MessageBlock::Image { source } => match source {
+            ImageSource::Base64 { media_type, data } => {
+                let data_url = format!("data:{};base64,{}", media_type, data);
+                json!({
+                    "type": "image_url",
+                    "image_url": {
+                        "url": data_url
+                    }
+                })
+            }
+            ImageSource::Url { url } => {
+                json!({
+                    "type": "image_url",
+                    "image_url": {
+                        "url": url
+                    }
+                })
+            }
+        },
+        MessageBlock::ImageUrl { image_url: _ } => to_value(block).unwrap_or_else(|_| json!(block)),
+        MessageBlock::Document { source } => match source {
+            DocumentSource::Base64 { media_type, data } => {
+                json!({
+                    "type": "text",
+                    "text": format!("[Document: {} (base64, {} bytes)]", media_type, data.len())
+                })
+            }
+        },
+        MessageBlock::DocumentUrl { document_url } => {
+            json!({
+                "type": "text",
+                "text": format!("[Document: {}]", document_url.url)
+            })
+        }
+    }
+}
 
 /// Generic message converter for OpenAI-compatible protocols
-pub fn openai_message_converter(messages: &[Message]) -> Vec<serde_json::Value> {
+pub fn openai_message_converter(messages: &[Message]) -> Vec<Value> {
     messages
         .iter()
         .map(|msg| {
@@ -16,29 +66,31 @@ pub fn openai_message_converter(messages: &[Message]) -> Vec<serde_json::Value> 
             };
 
             let content = if msg.content.len() == 1 && msg.content[0].is_text() {
-                serde_json::json!(msg.content[0].as_text().unwrap())
+                json!(msg.content[0].as_text().unwrap())
             } else {
-                serde_json::json!(msg.content)
+                // Convert each block to OpenAI-compatible format
+                let blocks = msg.content.iter().map(block_to_openai).collect::<Vec<_>>();
+                json!(blocks)
             };
 
             let mut map = serde_json::Map::new();
-            map.insert("role".to_string(), serde_json::json!(role));
+            map.insert("role".to_string(), json!(role));
             map.insert("content".to_string(), content);
 
             if let Some(ref tc) = msg.tool_calls {
-                map.insert("tool_calls".to_string(), serde_json::json!(tc));
+                map.insert("tool_calls".to_string(), json!(tc));
             }
             if let Some(ref id) = msg.tool_call_id {
-                map.insert("tool_call_id".to_string(), serde_json::json!(id));
+                map.insert("tool_call_id".to_string(), json!(id));
             }
             if let Some(ref name) = msg.name {
-                map.insert("name".to_string(), serde_json::json!(name));
+                map.insert("name".to_string(), json!(name));
             }
             if let Some(ref rc) = msg.reasoning_content {
-                map.insert("reasoning_content".to_string(), serde_json::json!(rc));
+                map.insert("reasoning_content".to_string(), json!(rc));
             }
 
-            serde_json::Value::Object(map)
+            Value::Object(map)
         })
         .collect()
 }
@@ -46,7 +98,7 @@ pub fn openai_message_converter(messages: &[Message]) -> Vec<serde_json::Value> 
 /// Downgrade message content for providers that only support text content
 pub fn openai_message_converter_downgrade(
     messages: &[Message],
-) -> Result<Vec<serde_json::Value>, LlmConnectorError> {
+) -> Result<Vec<Value>, LlmConnectorError> {
     messages
         .iter()
         .map(|msg| {
@@ -76,26 +128,26 @@ pub fn openai_message_converter_downgrade(
                 text_content
             };
 
-            let content = serde_json::json!(content_str);
+            let content = json!(content_str);
 
             let mut map = serde_json::Map::new();
-            map.insert("role".to_string(), serde_json::json!(role));
+            map.insert("role".to_string(), json!(role));
             map.insert("content".to_string(), content);
 
             if let Some(ref tc) = msg.tool_calls {
-                map.insert("tool_calls".to_string(), serde_json::json!(tc));
+                map.insert("tool_calls".to_string(), json!(tc));
             }
             if let Some(ref id) = msg.tool_call_id {
-                map.insert("tool_call_id".to_string(), serde_json::json!(id));
+                map.insert("tool_call_id".to_string(), json!(id));
             }
             if let Some(ref name) = msg.name {
-                map.insert("name".to_string(), serde_json::json!(name));
+                map.insert("name".to_string(), json!(name));
             }
             if let Some(ref rc) = msg.reasoning_content {
-                map.insert("reasoning_content".to_string(), serde_json::json!(rc));
+                map.insert("reasoning_content".to_string(), json!(rc));
             }
 
-            Ok(serde_json::Value::Object(map))
+            Ok(Value::Object(map))
         })
         .collect()
 }


### PR DESCRIPTION
fix: convert message blocks to OpenAI-compatible format for third-party providers

Some third-party providers (e.g. xiaomi) claiming OpenAI compatibility do not accept Anthropic-format message blocks (e.g., Image blocks with "source" field). While official OpenAI models can handle these formats, other providers may return errors like:
```
  "Value error, 'role' must be one of 'system', 'developer', 'assistant',
   'tool', or 'function' (case-insensitive)."
  "Input should be a valid string"
```
This change adds `block_to_openai()` function to properly convert MessageBlock variants to OpenAI-compatible JSON format:

- Text blocks -> {"type": "text", "text": "..."}
- Image blocks -> {"type": "image_url", "image_url": {"url": "..."}}
- Document blocks -> converted to text representation

The `openai_message_converter()` now uses this function when converting multi-block messages, ensuring compatibility with strict OpenAI-compatible APIs.