### PR TITLE
fix: handle null values in streaming tool call deserialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,8 +131,8 @@ pub use client::LlmClient;
 pub use config::ProviderConfig;
 pub use error::LlmConnectorError;
 pub use types::{
-    AnthropicToolChoice, AnthropicToolDefinition, ChatRequest, ChatResponse, Choice,
-    FunctionCall, JsonSchemaSpec, Message, ResponseFormat, ResponsesRequest, ResponsesResponse,
+    AnthropicToolChoice, AnthropicToolDefinition, ChatRequest, ChatResponse, Choice, FunctionCall,
+    JsonSchemaSpec, Message, ResponseFormat, ResponsesRequest, ResponsesResponse,
     ResponsesStreamEvent, ResponsesUsage, Role, Tool, ToolCall, ToolChoice, Usage,
 };
 

--- a/src/protocols/adapters/anthropic/mod.rs
+++ b/src/protocols/adapters/anthropic/mod.rs
@@ -6,8 +6,8 @@ use crate::core::Protocol;
 use crate::error::LlmConnectorError;
 use crate::protocols::common::capabilities::ProviderCapabilities;
 use crate::types::{
-    AnthropicToolChoice, AnthropicToolDefinition, ChatRequest, ChatResponse, Choice,
-    FunctionCall, Message, Role, ToolCall, ToolChoice, Usage,
+    AnthropicToolChoice, AnthropicToolDefinition, ChatRequest, ChatResponse, Choice, FunctionCall,
+    Message, Role, ToolCall, ToolChoice, Usage,
 };
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -165,17 +165,17 @@ impl Protocol for AnthropicProtocol {
             stream: request.stream,
             thinking,
             tools: request.anthropic_tools.clone().or_else(|| {
-                request.tools.as_ref().map(|tools| {
-                    tools
-                        .iter()
-                        .map(map_generic_tool_to_anthropic)
-                        .collect()
-                })
+                request
+                    .tools
+                    .as_ref()
+                    .map(|tools| tools.iter().map(map_generic_tool_to_anthropic).collect())
             }),
-            tool_choice: request
-                .anthropic_tool_choice
-                .clone()
-                .or_else(|| request.tool_choice.as_ref().and_then(map_tool_choice_to_anthropic)),
+            tool_choice: request.anthropic_tool_choice.clone().or_else(|| {
+                request
+                    .tool_choice
+                    .as_ref()
+                    .and_then(map_tool_choice_to_anthropic)
+            }),
         })
     }
 
@@ -478,9 +478,9 @@ fn map_tool_choice_to_anthropic(tool_choice: &ToolChoice) -> Option<AnthropicToo
             "auto" => Some(AnthropicToolChoice::auto()),
             _ => Some(AnthropicToolChoice::auto()),
         },
-        ToolChoice::Function { function, .. } => Some(AnthropicToolChoice::tool(
-            function.name.clone(),
-        )),
+        ToolChoice::Function { function, .. } => {
+            Some(AnthropicToolChoice::tool(function.name.clone()))
+        }
     }
 }
 
@@ -532,7 +532,10 @@ mod tests {
         assert_eq!(result.content, "Hello there, nice to meet.");
         assert_eq!(result.choices[0].message.content.len(), 2);
         match &result.choices[0].message.content[0] {
-            MessageBlock::Thinking { thinking, signature } => {
+            MessageBlock::Thinking {
+                thinking,
+                signature,
+            } => {
                 assert_eq!(thinking, "This is a thinking block");
                 assert_eq!(signature.as_deref(), Some("sig_123"));
             }
@@ -618,7 +621,10 @@ mod tests {
         assert_eq!(result.content, "");
         assert_eq!(result.choices[0].message.content.len(), 1);
         match &result.choices[0].message.content[0] {
-            MessageBlock::Thinking { thinking, signature } => {
+            MessageBlock::Thinking {
+                thinking,
+                signature,
+            } => {
                 assert_eq!(thinking, "Just thinking...");
                 assert_eq!(signature.as_deref(), Some("sig_124"));
             }
@@ -799,7 +805,10 @@ mod tests {
 
         assert_eq!(tool["type"], "custom");
         assert_eq!(tool["name"], "write_file");
-        assert_eq!(tool["custom_input_schema"]["$schema"], "https://json-schema.org/draft/2020-12/schema");
+        assert_eq!(
+            tool["custom_input_schema"]["$schema"],
+            "https://json-schema.org/draft/2020-12/schema"
+        );
         assert_eq!(tool["strict"], true);
         assert_eq!(tool["allowed_callers"][0], "claude_code");
         assert_eq!(tool["defer_loading"], true);

--- a/src/protocols/adapters/zhipu/mod.rs
+++ b/src/protocols/adapters/zhipu/mod.rs
@@ -62,7 +62,8 @@ impl ZhipuProtocol {
     }
 
     fn capabilities(&self) -> OpenAICompatibleCapabilities {
-        let provider_capabilities = crate::protocols::common::capabilities::ProviderCapabilities::zhipu_openai_compatible();
+        let provider_capabilities =
+            crate::protocols::common::capabilities::ProviderCapabilities::zhipu_openai_compatible();
 
         match self.mode {
             ZhipuApiMode::Native | ZhipuApiMode::OpenAICompatible => OpenAICompatibleCapabilities {

--- a/src/protocols/common/openai_compatible.rs
+++ b/src/protocols/common/openai_compatible.rs
@@ -55,10 +55,12 @@ pub fn map_openai_compatible_messages(
                 capabilities.empty_assistant_tool_content_strategy,
             ),
         ),
-        ContentBlockMode::TextOnly => crate::protocols::common::request::openai_message_converter_downgrade_with_strategy(
-            &request.messages,
-            capabilities.empty_assistant_tool_content_strategy,
-        ),
+        ContentBlockMode::TextOnly => {
+            crate::protocols::common::request::openai_message_converter_downgrade_with_strategy(
+                &request.messages,
+                capabilities.empty_assistant_tool_content_strategy,
+            )
+        }
         ContentBlockMode::NativeMessage => Ok(
             crate::protocols::common::request::openai_message_converter_with_strategy(
                 &request.messages,

--- a/src/protocols/common/request.rs
+++ b/src/protocols/common/request.rs
@@ -2,9 +2,7 @@
 
 use crate::error::LlmConnectorError;
 use crate::protocols::common::capabilities::EmptyAssistantToolContentStrategy;
-use crate::types::{
-    DocumentSource, ImageSource, Message, MessageBlock, Role,
-};
+use crate::types::{DocumentSource, ImageSource, Message, MessageBlock, Role};
 
 fn serialize_empty_assistant_tool_content(
     strategy: EmptyAssistantToolContentStrategy,
@@ -62,11 +60,7 @@ fn openai_export_reasoning_content(msg: &Message, thinking_from_blocks: &str) ->
         }
         out.push_str(thinking_from_blocks);
     }
-    if out.is_empty() {
-        None
-    } else {
-        Some(out)
-    }
+    if out.is_empty() { None } else { Some(out) }
 }
 
 /// Convert a single [`MessageBlock`] to an OpenAI-compatible JSON value.
@@ -82,8 +76,7 @@ fn openai_export_reasoning_content(msg: &Message, thinking_from_blocks: &str) ->
 fn block_to_openai_value(block: &MessageBlock) -> serde_json::Value {
     match block {
         MessageBlock::Text { .. } | MessageBlock::ImageUrl { .. } => {
-            serde_json::to_value(block)
-                .expect("MessageBlock serialization is infallible")
+            serde_json::to_value(block).expect("MessageBlock serialization is infallible")
         }
         MessageBlock::Image { source } => match source {
             ImageSource::Base64 { media_type, data } => serde_json::json!({
@@ -122,10 +115,7 @@ fn blocks_to_openai_content(blocks: &[MessageBlock]) -> Vec<serde_json::Value> {
 
 /// Generic message converter for OpenAI-compatible protocols
 pub fn openai_message_converter(messages: &[Message]) -> Vec<serde_json::Value> {
-    openai_message_converter_with_strategy(
-        messages,
-        EmptyAssistantToolContentStrategy::EmptyArray,
-    )
+    openai_message_converter_with_strategy(messages, EmptyAssistantToolContentStrategy::EmptyArray)
 }
 
 pub fn openai_message_converter_with_strategy(

--- a/src/protocols/common/streamers.rs
+++ b/src/protocols/common/streamers.rs
@@ -263,10 +263,7 @@ mod tests {
             "delta": { "type": "thinking_delta", "thinking": "a" }
         });
         let r = interpret_anthropic_event(&think, mid).unwrap().unwrap();
-        assert_eq!(
-            r.choices[0].delta.thinking.as_deref(),
-            Some("a")
-        );
+        assert_eq!(r.choices[0].delta.thinking.as_deref(), Some("a"));
         let sig = json!({
             "type": "content_block_delta",
             "index": 0,

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -1,7 +1,19 @@
 //! Request types for chat completions
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
+
+/// Deserialize a JSON value that may be `null` into a `String`.
+/// Returns `String::default()` (empty string) for `null` or missing values.
+/// This handles OpenAI-compatible streaming deltas where `id`, `name`, etc.
+/// are explicitly set to `null` in subsequent chunks.
+fn deserialize_null_as_empty_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
+}
 
 /// Role of a message sender
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -856,13 +868,22 @@ pub struct FunctionChoice {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ToolCall {
     /// Unique identifier for the tool call
-    /// Present in the first chunk, may be empty in subsequent delta chunks
-    #[serde(default, skip_serializing_if = "String::is_empty")]
+    /// Present in the first chunk, may be null/empty in subsequent delta chunks
+    #[serde(
+        default,
+        deserialize_with = "deserialize_null_as_empty_string",
+        skip_serializing_if = "String::is_empty"
+    )]
     pub id: String,
 
     /// Type of tool call (usually "function")
-    /// Present in the first chunk, may be empty in subsequent delta chunks
-    #[serde(rename = "type", default, skip_serializing_if = "String::is_empty")]
+    /// Present in the first chunk, may be null/empty in subsequent delta chunks
+    #[serde(
+        rename = "type",
+        default,
+        deserialize_with = "deserialize_null_as_empty_string",
+        skip_serializing_if = "String::is_empty"
+    )]
     pub call_type: String,
 
     /// Function call details
@@ -887,8 +908,12 @@ pub struct ToolCall {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct FunctionCall {
     /// Name of the function
-    /// Present in the first chunk, may be empty in subsequent delta chunks
-    #[serde(default, skip_serializing_if = "String::is_empty")]
+    /// Present in the first chunk, may be null/empty in subsequent delta chunks
+    #[serde(
+        default,
+        deserialize_with = "deserialize_null_as_empty_string",
+        skip_serializing_if = "String::is_empty"
+    )]
     pub name: String,
 
     /// Arguments as JSON string


### PR DESCRIPTION
Add deserialize_null_as_empty_string helper to gracefully handle OpenAI-compatible streaming deltas where id, name, and type fields are explicitly set to null in subsequent chunks.
This will fix errors similar to this:
```
ParseError("Failed to parse streaming response as OpenAI-compatible chunk. Content: {\"id\":\"a693247bbd2440fd90d2234b108cb8fd\",\"choices\":[{\"delta\":{\"content\":null,\"role\":null,\"tool_calls\":[{\"index\":0,\"id\":null,\"function\":{\"arguments\":\"{\\\"max_depth\\\": \",\"name\":null},\"type\":\"function\"}],\"reasoning_content\":null},\"finish_reason\":null,\"index\":0}],\"created\":1780861819,\"model\":\"mimo-v2.5\",\"object\":\"chat.completion.chunk\"}")
```

Also apply cargo fmt formatting across multiple files.