### PR TITLE
Open AI: Add stream_options field (mainly for usage stats).

### DIFF
--- a/src/protocols/adapters/openai/mod.rs
+++ b/src/protocols/adapters/openai/mod.rs
@@ -6,8 +6,8 @@ use crate::core::Protocol;
 use crate::error::LlmConnectorError;
 use crate::protocols::common::capabilities::{ContentBlockMode, ProviderCapabilities};
 use crate::protocols::common::openai_compatible::{
-    OpenAICompatibleCapabilities, build_openai_compatible_request_parts,
-    parse_openai_compatible_chat_response,
+    build_openai_compatible_request_parts, parse_openai_compatible_chat_response,
+    OpenAICompatibleCapabilities,
 };
 use crate::protocols::common::transport::resolve_endpoint;
 use crate::types::{
@@ -153,6 +153,7 @@ impl Protocol for OpenAIProtocol {
             frequency_penalty: request.frequency_penalty,
             presence_penalty: request.presence_penalty,
             stream: request.stream,
+            stream_options: request.stream_options.clone(),
             tools: parts.tools,
             tool_choice: parts.tool_choice,
             response_format: parts.response_format,
@@ -333,6 +334,8 @@ pub struct OpenAIRequest {
     pub presence_penalty: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -51,6 +51,10 @@ pub struct ChatRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
 
+    /// Stream options (e.g. '{ "include_usage": true }")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<serde_json::Value>,
+
     /// Stop sequences
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop: Option<Vec<String>>,
@@ -197,6 +201,12 @@ impl ChatRequest {
     /// Enable streaming
     pub fn with_stream(mut self, stream: bool) -> Self {
         self.stream = Some(stream);
+        self
+    }
+
+    /// Set stream options (e.g. '{ "include_usage": true }")
+    pub fn with_stream_options(mut self, stream_options: serde_json::Value) -> Self {
+        self.stream_options = Some(stream_options);
         self
     }
 


### PR DESCRIPTION
This is mainly useful to enable usage stats using `{"include_usage": true}` which looks like:

```
StreamingResponse { id: "chatcmpl-MVjpRrGNCyklchE0GqksUQJWgIRD5XJy", object: "chat.completion.chunk", created: 1787185838, model: "unsloth/Qwen3.8-27B-GGUF:UD-Q3_K_XL", choices: [], content: "", reasoning_content: None, usage: Some(Usage { prompt_tokens: 2610, completion_tokens: 195, total_tokens: 2805, prompt_cache_hit_tokens: None, prompt_cache_miss_tokens: None, prompt_tokens_details: Some(PromptTokensDetails { cached_tokens: Some(2094), cache_read_input_tokens: None, cache_creation_input_tokens: None }), completion_tokens_details: None }), system_fingerprint: Some("b10491-0882c7bc8") }
```

See Open AI `stream_options` documentation [here](https://developers.openai.com/api/reference/resources/chat#(resource)%20chat.completions%20%3E%20(model)%20chat_completion_stream_options%20%3E%20(schema)).